### PR TITLE
FOGL-3314: AssetTracker call missing in simple-python filter

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -256,12 +256,18 @@ void plugin_ingest(PLUGIN_HANDLE *handle,
 
 	PyGILState_Release(state);
 
-	// 2- optionally free reading set
-	// delete (ReadingSet *)readingSet;
-	// With the above DataPointValue change we don't need to free input data
 
-	// 3- pass newReadings to filter->m_func instead of readings if needed.
-	// With the value change we can pass same input readingset just modified
+	// Call asset tracker
+	for (vector<Reading *>::const_iterator elem = readings->begin();
+						      elem != readings->end();
+						      ++elem)
+	{
+		AssetTracker::getAssetTracker()->addAssetTrackingTuple(filter->getConfig().getName(),
+									(*elem)->getAssetName(),
+									string("Filter"));
+	}
+
+	// Pass readingSet to the next filter
 	filter->m_func(filter->m_data, readingSet);
 }
 


### PR DESCRIPTION
FOGL-3314: AssetTracker add event entry is missing in plugin_ingest def for filter-simple-python plugin

sqlite> select * from asset_tracker;

7|randomwalk|Filter|Rand3|FogLAMP|Code1|2019-09-30 11:27:18.053
8|walk2|Filter|Rand2|FogLAMP|Fil2|2019-09-30 11:30:04.628